### PR TITLE
Removed Environment Variable from template.yaml

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -9,9 +9,6 @@ Description: >
 Globals:
   Function:
     Timeout: 5
-    Environment:
-      Variables:
-        firestoreCred:
 
 Resources:
   HealthCheckFunction:

--- a/template.yaml
+++ b/template.yaml
@@ -9,6 +9,9 @@ Description: >
 Globals:
   Function:
     Timeout: 5
+    Environment:
+      Variables:
+        firestoreCred: YourFirestoreCredentials
 
 Resources:
   HealthCheckFunction:


### PR DESCRIPTION
Removed firebaseCred Environment Variable from template.yaml as it is giving error while deploying because we can't send empty environment variables.

Closes #27 