### PR TITLE
Added a work around to fix the build failing

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -34,7 +34,7 @@ jobs:
       - uses: aws-actions/setup-sam@v1
 
       - name: Build resources
-        run: sam build --template ${SAM_TEMPLATE} --use-container --debug
+        run: sam build --template ${SAM_TEMPLATE} --use-container --build-image public.ecr.aws/sam/build-go1.x:1.107.0-20240110194920 --debug
 
       - name: Assume the pipeline user role
         env:


### PR DESCRIPTION
Date: 16/01/2024 
Developer Name: @lakshayman  

---

## Description

The build is failing while we build the SAM project inside the container of the Al2023 image from the image repository provided by AWS. It is explained and discussed in this issue https://github.com/aws/aws-sam-cli/issues/5280

The workaround is to provide the Go1.x image to build the project.